### PR TITLE
Client-heartbeat realization fix

### DIFF
--- a/src/utils/functions.ts
+++ b/src/utils/functions.ts
@@ -46,3 +46,7 @@ export const reorder = (list: any, startIndex: number, endIndex: number) => {
   result.splice(endIndex, 0, removed)
   return result
 }
+
+export const getCurrentSeconds = () => {
+  return new Date().getTime() / 1000
+}

--- a/src/utils/stomp.ts
+++ b/src/utils/stomp.ts
@@ -30,4 +30,6 @@ const send = (path: string, msg: string = '', contentType = 'application/json') 
   return message
 }
 
-export default { connect, subscribe, send, getJson }
+const defaultWriteHeartbeatInterval = 20
+
+export default { connect, subscribe, send, getJson, defaultWriteHeartbeatInterval }


### PR DESCRIPTION
This commit fixes incorrect client-heartbeat realization in mucpoll-ts.  
The server dropped master-client (Poller) with a 1002 error because there wasn't a client-heartbeat. Example: many connections during one minute. The server assumes that regular messages can be server-heartbeat too. But the client sent client-heartbeat only to explicit server-heartbeat.  
New implementation checks a heartbeat timer with every message. Then it sends the client-heartbeat.